### PR TITLE
Fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The structure of an extension repository should look like:
     └── milestoneType.csv (Overwrite the existing codelist - not recommended)
 ```
 
-This copies the layout of the core [standards repository](https://github.com/open-contracting/standard/tree/HEAD/standard/schema).
+This copies the layout of the core [standards repository](https://github.com/open-contracting/standard/tree/HEAD/schema).
 
 ### Schema files
 


### PR DESCRIPTION
Replace
https://github.com/open-contracting/standard/tree/HEAD/standard/schema
With
https://github.com/open-contracting/standard/tree/HEAD/schema

Repo name not required twice in URL